### PR TITLE
Proxy less

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 A state-management library that runs on technology and magic.
 
 ```
-┌──────────────────────────────────────────────┐
-│                                              │
-│   Bundle size: 1.9 KB, Gzipped size: 774 B   │
-│                                              │
-└──────────────────────────────────────────────┘
+┌───────────────────────────────────────────────┐
+│                                               │
+│   Bundle size: 2.15 KB, Gzipped size: 799 B   │
+│                                               │
+└───────────────────────────────────────────────┘
 ```
 
 ## You've got to have POWER!
@@ -22,7 +22,7 @@ Hover-Engine gives your app the following super-powers:
 * Notify as many listeners as you want!
 * Handle async (or chained) action calls with [semi-predictable results](https://en.wikipedia.org/wiki/Magic_\(illusion\))!
 * No Dependencies!
-* Light enough to give you flight (less than 2 KB)!
+* Light enough to give you flight (~2 KB)!
 
 ## Install
 ```bash
@@ -93,11 +93,11 @@ The `init` action is called after `engine.addActions` runs. It is passed no argu
 ```javascript
 const temperatureActions = {
   init: () => 70,
-  
+
   increaseTemp: (temp) => temp + 1,
-  
+
   setTemperature: (temp, newTemp) => newTemp,
-  
+
   pullTemperatureFromZipcode: (temp, zipCode, actions) => {
     fetch('some.temperature.api/' + zipCode)
       .then((tempData) => actions.setTemperature(tempData))

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A state-management library that runs on technology and magic.
 ```
 ┌───────────────────────────────────────────────┐
 │                                               │
-│   Bundle size: 2.15 KB, Gzipped size: 799 B   │
+│   Bundle size: 2.09 KB, Gzipped size: 794 B   │
 │                                               │
 └───────────────────────────────────────────────┘
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hover-engine",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "a state-management library that runs on technology and magic",
   "main": "dist/hover-engine.js",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,10 @@ const plugins = [
   babel({
     presets: [
       ['env', {
+        targets: {
+          node: '6.10',
+          browsers: ['last 2 versions', 'safari >= 10', 'ie 11']
+        },
         modules: false
       }]
     ]

--- a/specs/hover-engine-specs.js
+++ b/specs/hover-engine-specs.js
@@ -262,15 +262,6 @@ describe('HoverEngine', () => {
       // dequeue (b's) increment -> { A: 3, B: 3 }, queue: []
       expect(engine.store.A).toEqual(3)
     })
-
-    it('should not modify the store if the action does not exist', () => {
-      const spies = {increment: jasmine.createSpy('a.increment')}
-      engine.addActions(ag.singleActionGroup(spies))
-      engine.actions.increment()
-      expect(engine.store.A).toEqual(1)
-      engine.actions.undefined()
-      expect(engine.store.A).toEqual(1)
-    })
   })
 
   describe('store', () => {

--- a/specs/hover-engine-specs.js
+++ b/specs/hover-engine-specs.js
@@ -123,34 +123,20 @@ describe('HoverEngine', () => {
       expect(spyB).toHaveBeenCalled()
     })
 
-    it('should call listener with updated store', () => {
-      let trap
-      const returnArgs = (store, actions) => {
-        trap = {store, actions}
-      }
-      engine.addListener(returnArgs)
-
+    it('should call listener with store and actions', () => {
+      const listenerSpy = jasmine.createSpy('listener')
       engine.addActions(ag.singleActionGroup())
+      engine.addListener(listenerSpy)
       engine.notifyListeners()
-
-      expect(trap.store).toEqual(engine.store)
+      expect(listenerSpy).toHaveBeenCalledWith(engine.store, engine.actions)
     })
 
-    it('should call listener with actions', () => {
-      let trap
-      const returnArgs = (store, actions) => {
-        trap = {store, actions}
-      }
-      engine.addListener(returnArgs)
-
+    it('should call listener with updated store', () => {
+      const listenerSpy = jasmine.createSpy('listener')
       engine.addActions(ag.singleActionGroup())
-      engine.notifyListeners()
-      expect(trap.store.A).toEqual(0)
-
-      // can't inspect actions, so we'll just make
-      // sure it can do what actions can do
-      trap.actions.increment()
-      expect(trap.store.A).toEqual(1)
+      engine.addListener(listenerSpy)
+      engine.actions.increment()
+      expect(listenerSpy).toHaveBeenCalledWith(jasmine.objectContaining({A: 1}), jasmine.anything())
     })
 
     it('should be chainable', () => {
@@ -216,23 +202,13 @@ describe('HoverEngine', () => {
     })
 
     it('should pass arguements into the action', () => {
-      let trap
-      const argsSpy = (state, value, actions) => {
-        trap = {state, value, actions}
-      }
+      const argsSpy = jasmine.createSpy('args spy')
 
       const spies = {increment: argsSpy}
       engine.addActions(ag.argsActionGroup(spies))
       engine.actions.increment(10)
 
-      expect(trap.state).toEqual(0)
-      expect(trap.value).toEqual(10)
-
-      // can't inspect actions, so we'll just make
-      // sure it can do what actions can do
-      expect(engine.store.A).toEqual(1)
-      trap.actions.increment()
-      expect(engine.store.A).toEqual(2)
+      expect(argsSpy).toHaveBeenCalledWith(0, 10, engine.actions)
     })
 
     it('should be chainable off of actons arguement', () => {


### PR DESCRIPTION
In an attempt to support IE (any version), hover-engine needs to either not have proxies, or have a proxy-polyfill. Since a proxy-polyfill is [impossible](https://stackoverflow.com/questions/45285992/es6-proxy-polyfill-for-ie11) we have decided to remove the proxy.

## Changes
- remove proxy in favor of object with methods 🔪 
- increase build size to over 2KB 😢 
- update specs to be more straightforward (since we can inspect and stuff) 🎉 